### PR TITLE
修正：刪除檔名中不合法字元、修正關閉視窗時任務繼續下載

### DIFF
--- a/JableTVJob.py
+++ b/JableTVJob.py
@@ -76,6 +76,7 @@ class JableTVJob:
             if htmlfile.status_code == 200:
                 result = re.search('og:title".+/>', htmlfile.text)
                 self._targetName = result[0].split('"')[-2]
+                self._targetName =  re.sub(r'[^\w\-_\. ]', '', self._targetName)
                 result = re.search('og:image".+jpg"', htmlfile.text)
                 self._imageUrl = result[0].split('"')[-2]
                 result = re.search("https://.+m3u8", htmlfile.text)
@@ -277,7 +278,8 @@ class JableTVJob:
         print("\n下載已取消!!!", flush=True)
 
     def begin_concurrent_download(self):
-        self._t_executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        max_worker = os.cpu_count()
+        self._t_executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_worker)
         self._t_future = self._t_executor.submit(self.start_download)
 
     def is_concurrent_dowload_completed(self):

--- a/gui.py
+++ b/gui.py
@@ -173,9 +173,9 @@ class JableTVDownloadWindow(tk.Tk):
     def _on_window_closed(self):
         self._is_abort = True
         self._urls_list = []
-        self.on_cancel_download()
+        self.on_terminate_window()
         self.save_on_close()
-        self.destroy()
+        os._exit(0)
 
     def _get_entry_values(self):
         self.dest = self.dest_entry.get()
@@ -207,6 +207,16 @@ class JableTVDownloadWindow(tk.Tk):
             self.btn_cancel["state"] = tk.NORMAL
         else:
             self.btn_cancel["state"] = tk.DISABLED
+
+    def on_terminate_window(self):
+        self._terminateJob, self._currentJob = self._currentJob, None
+        for i in range(len(self._download_list), 0, -1):
+            delete_url = self._download_list[i-1]
+            self.tree.update_item_state(delete_url[0], "已取消")
+            self._download_list.remove(delete_url)
+        if(self._terminateJob):
+            self.tree.update_item_state(self._terminateJob.get_url_short(), "未完成")
+            threading.Thread(target=self._terminateJob.cancel_download).start()  
 
     def on_cancel_all_download(self):
         self._cancel_all = True


### PR DESCRIPTION
1. 使用正則表達式刪除不合法字元，未加入判斷式會讓合成後影片無法存檔，[測試案例](https://jable.tv/videos/ssis-158/)。
2. 修正當程式正在下載時，關閉 JableTV 視窗後，程式會持續下載。